### PR TITLE
v0.3.1

### DIFF
--- a/Formula/flowctl.rb
+++ b/Formula/flowctl.rb
@@ -2,15 +2,16 @@ class Flowctl < Formula
   desc "Command line interface for Flow"
   homepage "https://github.com/estuary/flow"
   # When updating this formula to a new version, you need to update this url as well as the `sha256` and `version` below!
-  url "https://github.com/estuary/flow/archive/refs/tags/v0.3.0.tar.gz"
-  sha256 "688f569e673a2114a8a1e7b5160b615ac8ecbaebc0f10030750dc1285e9db7b2"
+  # For example: `shasum -a 256 v0.3.1.tar.gz`
+  url "https://github.com/estuary/flow/archive/refs/tags/v0.3.1.tar.gz"
+  sha256 "aa4ccc32b8a014a77462c607fe7bfc8517de5b92d1711bbd105318de77f0fd80"
   license "Business Source License 1.1"
-  version "0.3.0"
+  version "0.3.1"
 
   on_macos do
     resource "flowctl-binary" do
       url "https://github.com/estuary/flow/releases/download/v#{Flowctl.version}/flowctl-multiarch-macos"
-      sha256 "4a390e92be3bcd4424726ca72fcd03ffb545b973cc6c29101019a9078f78f3e5"
+      sha256 "8880687b61cd8c742d5a5f880bc72b68451dc5b3d5eb8bcaf903cf238462b4e9"
     end
   end
 
@@ -20,7 +21,7 @@ class Flowctl < Formula
     end
     resource "flowctl-binary" do
       url "https://github.com/estuary/flow/releases/download/v#{Flowctl.version}/flowctl-x86_64-linux"
-      sha256 "24d69afbf8f25b8f229b42101b5bcf6fd16be5a21c4be840c1240831b162c684"
+      sha256 "a174bf8de2809d1d80f2307f4fa6a357f6d42b96b26faa6d9cec3e5781638f7e"
     end
   end
 


### PR DESCRIPTION
Tested locally, fairly sure this means it works correctly:

![Screen Shot 2023-07-10 at 17 53 09](https://github.com/estuary/homebrew-flowctl/assets/4368270/25ea98a2-fd54-4e9b-91c0-7a316222e665)
